### PR TITLE
New ArtNet packet sending behaviour when idling

### DIFF
--- a/drivers/artnet.js
+++ b/drivers/artnet.js
@@ -6,7 +6,7 @@ const STATE_STOPPED = 0;
 const STATE_IDLE = 1;
 const STATE_QUICK_REFRESH = 2;
 
-// See page 45: https://artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf 
+// See page 45: https://artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf
 const UNIVERSE_IDLE_RETRANSMIT_INTERVAL = 800;
 
 function ArtnetDriver(deviceId = '127.0.0.1', options = {}) {
@@ -84,16 +84,18 @@ ArtnetDriver.prototype.moveToState = function (state) {
     clearInterval(this.transmissionIntervalTimer);
   }
 
-  if (state === STATE_IDLE) {
-    this.transmissionIntervalTimer = setInterval(
-      this.sendUniverse.bind(this),
-      UNIVERSE_IDLE_RETRANSMIT_INTERVAL
-    );
-  } else if (state === STATE_QUICK_REFRESH) {
-    this.quickRefreshTimeout = false;
-    this.sendUniverse();
-    this.transmissionIntervalTimer = setInterval(
-      (() => {
+  switch (state) {
+    case STATE_IDLE:
+      this.transmissionIntervalTimer = setInterval(
+        this.sendUniverse.bind(this),
+        UNIVERSE_IDLE_RETRANSMIT_INTERVAL
+      );
+      break;
+
+    case STATE_QUICK_REFRESH:
+      this.quickRefreshTimeout = false;
+      this.sendUniverse();
+      this.transmissionIntervalTimer = setInterval(() => {
         // Final quick refresh has happened and universe still not updated, revert to IDLE
         if (this.quickRefreshTimeout) {
           this.moveToState(STATE_IDLE);
@@ -105,9 +107,11 @@ ArtnetDriver.prototype.moveToState = function (state) {
             this.quickRefreshTimeout = true;
           }
         }
-      }).bind(this),
-      this.interval
-    );
+      }, this.interval);
+      break;
+
+    default:
+      break;
   }
 };
 


### PR DESCRIPTION
Implements the following state machine:

On driver startup, move to `IDLE`

**IDLE**
- Re-transmit universe values every 800ms (as per docs)

**QUICK REFRESH**
- Re-transmit universe once per `interval` (default is 44Hz).
- If universe has not had changes since last send, stay in `QUICK REFRESH` for one more loop (in order to catch case when animation updates to universe are slightly out of sync with refresh times).
- If universe still has had no changes after final loop, move to `IDLE`

With this change I have been unable to reproduce the previous problem with the ArtNet node.